### PR TITLE
ci: build extension on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+
+      - name: Install dependencies
+        working-directory: extension
+        run: npm ci
+
+      - name: Build
+        working-directory: extension
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: npm run build


### PR DESCRIPTION
Adds a CI workflow that runs `npm ci` + `npm run build` on every PR (and on pushes to `master`), so changes are verified before merge instead of only at release time.

Mirrors `package.yml` conventions: Node 20, npm cache keyed on `extension/package-lock.json`.

Addresses the **build-on-PR** half of #25. ESLint + Prettier (the other half) will follow as a separate PR — Prettier reformats the whole codebase, so it's best done after the open Dependabot PRs (#14–18) are merged, to avoid conflicts.

This PR also self-tests the workflow: the `pull_request` trigger means CI runs on this PR itself.