### PR TITLE
fix: pass magic-link session via storage, not the URL (ERR_BLOCKED_BY_CLIENT)

### DIFF
--- a/extension/public/background.js
+++ b/extension/public/background.js
@@ -1,12 +1,18 @@
 // Auth redirect interceptor
-// Chrome blocks redirects to chrome-extension:// URLs from external sites.
-// This service worker watches for Supabase auth callbacks and navigates
-// the tab to the extension page with the auth tokens intact.
+// Chrome blocks redirects to chrome-extension:// URLs from external sites, so
+// this service worker watches for Supabase auth callbacks and forwards the
+// session to the extension page.
+//
+// The auth payload is stashed in chrome.storage and the tab is navigated to a
+// CLEAN extension URL (no token in the URL). This keeps tokens out of the page
+// URL/history and avoids content/privacy blockers that match token params in
+// the URL (which surfaced as ERR_BLOCKED_BY_CLIENT on the redirect).
 
 const SUPABASE_HOST = 'eeidclmhfkndimghdyuq.supabase.co';
 const EXTENSION_PAGE = 'src/newtab.html';
+const AUTH_STASH_KEY = 'dn_auth_redirect';
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (!changeInfo.url) return;
 
   let url;
@@ -18,24 +24,19 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 
   if (url.hostname !== SUPABASE_HOST) return;
 
-  // Implicit flow: #access_token=...
-  if (url.hash && url.hash.includes('access_token=')) {
-    const extensionUrl = chrome.runtime.getURL(EXTENSION_PAGE) + url.hash;
-    chrome.tabs.update(tabId, { url: extensionUrl });
-    return;
+  let payload = null;
+  if (url.hash && (url.hash.includes('access_token=') || url.hash.includes('error='))) {
+    // Implicit flow (#access_token=...) or error (#error=...)
+    payload = { kind: 'hash', value: url.hash.replace(/^#/, '') };
+  } else if (url.searchParams.has('code')) {
+    // PKCE flow (?code=...)
+    payload = { kind: 'query', value: url.searchParams.toString() };
   }
 
-  // Error redirect: #error=...
-  if (url.hash && url.hash.includes('error=')) {
-    const extensionUrl = chrome.runtime.getURL(EXTENSION_PAGE) + url.hash;
-    chrome.tabs.update(tabId, { url: extensionUrl });
-    return;
-  }
+  if (!payload) return;
 
-  // PKCE flow: ?code=...
-  if (url.searchParams.has('code')) {
-    const extensionUrl = chrome.runtime.getURL(EXTENSION_PAGE) + '?' + url.searchParams.toString();
-    chrome.tabs.update(tabId, { url: extensionUrl });
-    return;
-  }
+  // Stash the payload out-of-band, then navigate to a clean extension URL.
+  chrome.storage.local.set({ [AUTH_STASH_KEY]: payload }, () => {
+    chrome.tabs.update(tabId, { url: chrome.runtime.getURL(EXTENSION_PAGE) });
+  });
 });

--- a/extension/src/store/auth.js
+++ b/extension/src/store/auth.js
@@ -15,7 +15,48 @@ async function checkAdmin(userId) {
   isAdmin.value = !!data;
 }
 
+const AUTH_STASH_KEY = 'dn_auth_redirect';
+
+// Pick up an auth payload stashed by the service worker (background.js) after a
+// magic-link redirect. Tokens are passed via chrome.storage instead of in the
+// URL, so they never appear in the page URL/history and aren't blocked by
+// content/privacy blockers (ERR_BLOCKED_BY_CLIENT).
+async function consumeAuthRedirect() {
+  const storage = globalThis.chrome?.storage?.local;
+  if (!storage) return;
+
+  let payload;
+  try {
+    const stored = await storage.get(AUTH_STASH_KEY);
+    payload = stored?.[AUTH_STASH_KEY];
+    if (!payload) return;
+    await storage.remove(AUTH_STASH_KEY);
+  } catch {
+    return;
+  }
+
+  try {
+    if (payload.kind === 'hash') {
+      const params = new URLSearchParams(payload.value);
+      const access_token = params.get('access_token');
+      const refresh_token = params.get('refresh_token');
+      if (access_token && refresh_token) {
+        await supabase.auth.setSession({ access_token, refresh_token });
+      } else {
+        const err = params.get('error_description') || params.get('error');
+        if (err) console.error('Auth redirect error:', err);
+      }
+    } else if (payload.kind === 'query') {
+      const code = new URLSearchParams(payload.value).get('code');
+      if (code) await supabase.auth.exchangeCodeForSession(code);
+    }
+  } catch (e) {
+    console.error('Failed to establish session from auth redirect:', e);
+  }
+}
+
 export async function initAuth() {
+  await consumeAuthRedirect();
   const { data: { session } } = await supabase.auth.getSession();
   user.value = session?.user || null;
   authLoading.value = false;


### PR DESCRIPTION
## Bug
A user (returning, with a working account) hit **`ERR_BLOCKED_BY_CLIENT`** on the magic-link confirmation, address bar showing `chrome-extension://…`. That error is produced by a content/privacy blocker extension on the user's own browser.

## Root cause
The magic-link redirect lands on `…/src/newtab.html#access_token=…` (or `?code=…`). The auth token in that URL is what the blocker matched — the user's normal new-tab loads fine; only the token-bearing redirect was blocked. Not a packaging/code defect (auth logs show the flow working for other users), but the token-in-URL design is fragile against blockers (and leaks tokens into URL/history).

## Fix
The service worker now stashes the auth payload in `chrome.storage.local` and navigates the tab to a **clean** extension URL (no token in the URL). `initAuth()` reads the stashed payload and establishes the session via `setSession` (implicit) / `exchangeCodeForSession` (PKCE), then clears it. Tokens never appear in the URL or history.

Files: `extension/public/background.js`, `extension/src/store/auth.js`.

## ⚠️ Do not merge without a real login test
This changes the live login flow for **all** users. CI only builds — it does not exercise login. Before merge:
1. Load the branch build (`extension/dist/` via chrome://extensions → Load unpacked).
2. Sign out, request a magic link, click it.
3. Confirm the session establishes (lands on the dashboard signed-in) and the URL bar shows a clean `…/newtab.html` (no token).
Ideally also confirm with the affected user (with their blocker still on).